### PR TITLE
fixed crash when viewing unicode jsons

### DIFF
--- a/simplenote_cli/temp.py
+++ b/simplenote_cli/temp.py
@@ -7,7 +7,7 @@ import os, json, tempfile
 def tempfile_create(note, raw=False):
     if raw:
         # dump the raw json of the note
-        tf = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
+        tf = tempfile.NamedTemporaryFile(mode = 'w+', suffix='.json', delete=False)
         json.dump(note, tf, indent=2)
         tf.flush()
     else:


### PR DESCRIPTION
tempfile is opened in binary mode by default unless specified otherwise: https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile

This crashed the JSON view whenever the text contained some unicode characters. 