### PR TITLE
Add `cfg_tempdir` option

### DIFF
--- a/simplenote_cli/config.py
+++ b/simplenote_cli/config.py
@@ -27,6 +27,7 @@ class Config:
          'cfg_log_timeout'       : '5',
          'cfg_log_reversed'      : 'yes',
          'cfg_sn_host'           : 'simple-note.appspot.com',
+         'cfg_tempdir'           : '',
 
          'kb_help'            : 'h',
          'kb_quit'            : 'q',
@@ -151,6 +152,7 @@ class Config:
         self.configs['max_logs'] = [ cp.get(cfg_sec, 'cfg_max_logs'), 'Max logs in footer' ]
         self.configs['log_timeout'] = [ cp.get(cfg_sec, 'cfg_log_timeout'), 'Log timeout' ]
         self.configs['log_reversed'] = [ cp.get(cfg_sec, 'cfg_log_reversed'), 'Log file reversed' ]
+        self.configs['tempdir'] = [ cp.get(cfg_sec, 'cfg_tempdir'), 'Temporary directory for note storage' ]
 
         self.keybinds = collections.OrderedDict()
         self.keybinds['help'] = [ cp.get(cfg_sec, 'kb_help'), [ 'common' ], 'Help' ]

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -22,6 +22,10 @@ class sncli:
         force_full_sync     = False
         self.current_sort_mode = self.config.get_config('sort_mode')
 
+        self.tempdir = self.config.get_config('tempdir')
+        if self.tempdir == '':
+            self.tempdir = None
+
         if not os.path.exists(self.config.get_config('db_path')):
             os.mkdir(self.config.get_config('db_path'))
             force_full_sync = True
@@ -91,7 +95,7 @@ class sncli:
         if not cmd:
             return None
 
-        tf = temp.tempfile_create(note if note else None, raw=raw)
+        tf = temp.tempfile_create(note if note else None, raw=raw, tempdir=self.tempdir)
 
         try:
             subprocess.check_call(cmd + ' ' + temp.tempfile_name(tf), shell=True)
@@ -119,9 +123,9 @@ class sncli:
         if not pager:
             return None
 
-        ltf = temp.tempfile_create(note)
-        otf = temp.tempfile_create(old_note)
-        out = temp.tempfile_create(None)
+        ltf = temp.tempfile_create(note, tempdir=self.tempdir)
+        otf = temp.tempfile_create(old_note, tempdir=self.tempdir)
+        out = temp.tempfile_create(None, tempdir=self.tempdir)
 
         try:
             subprocess.call(diff + ' ' + 

--- a/simplenote_cli/temp.py
+++ b/simplenote_cli/temp.py
@@ -4,10 +4,10 @@
 
 import os, json, tempfile
 
-def tempfile_create(note, raw=False):
+def tempfile_create(note, raw=False, tempdir=None):
     if raw:
         # dump the raw json of the note
-        tf = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
+        tf = tempfile.NamedTemporaryFile(suffix='.json', delete=False, dir=tempdir)
 
         contents = json.dumps(note, indent=2)
         tf.write(contents.encode('utf-8'))
@@ -18,7 +18,7 @@ def tempfile_create(note, raw=False):
            'systemtags' in note and \
            'markdown' in note['systemtags']:
             ext = '.mkd'
-        tf = tempfile.NamedTemporaryFile(suffix=ext, delete=False)
+        tf = tempfile.NamedTemporaryFile(suffix=ext, delete=False, dir=tempdir)
         if note:
             contents = note['content']
             tf.write(contents.encode('utf-8'))


### PR DESCRIPTION
This allows users to set their own, possibly more persistent temporary
directory. If the parameter is blank (default), the argument is set to
`None`, which is the default for `tempfile.NamedTemporaryFile`.

Storing temporary files somewhere other than `tmp` is slightly safer in
cases if, say, the computer shuts down abnormally and a note is saved
but the editor is still open (before this change, the note's content
would be lost since the `tmp` directory is wiped on restart).