### PR TITLE
Basic tag command line API

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Usage:
   < trash | untrash >         - trash/untrash a note (specified by <key>)
   < pin | unpin >             - pin/unpin a note (specified by <key>)
   < markdown | unmarkdown >   - markdown/unmarkdown a note (specified by <key>)
+  tag get                     - retrieve the tags from a note (specified by <key>)
+  tag set <tags>              - set the tags for a note (specified by <key>)
+  tag add <tags>              - add tags to a note (specified by <key>)
+  tag rm <tags>               - remove tags from a note (specified by <key>)
 ```
 
 #### Configuration

--- a/README.md
+++ b/README.md
@@ -234,6 +234,27 @@ Note that sncli still stores all the notes data in the directory specified by
 `cfg_db_path`, so for easy backups, it may be easier/quicker to simply backup
 this entire directory.
 
+### Tags
+
+Note tags can be modified directly from the command line. Example:
+
+```
+# Retrieve note tags, as one comma-separated string (e.g. "tag1,tag2")
+sncli -k somekeyid tag get                  # Returns "tag1,tag2"
+
+# Add a tag to a note, if it doesn't already have it
+sncli -k somekeyid tag add "tag4"           # Now tagged as "tag2,tag3,tag4"
+
+# Remove a tag from a note
+sncli -k somekeyid tag rm "tag3"            # Now tagged as "tag2,tag4"
+
+# Overwrite all of the tags for a note
+sncli -k somekeyid tag set "tag2,tag3"      # Now tagged as "tag2,tag3"
+```
+
+Note that in SimpleNote, tags are case-insensitive, so "TAG2", "tag2", and 
+"tAg2" are interpreted as the same and will all be converted to lowercase.
+
 
 ### Tricks
 

--- a/README.md
+++ b/README.md
@@ -247,13 +247,13 @@ Note tags can be modified directly from the command line. Example:
 sncli -k somekeyid tag get                  # Returns "tag1,tag2"
 
 # Add a tag to a note, if it doesn't already have it
-sncli -k somekeyid tag add "tag4"           # Now tagged as "tag2,tag3,tag4"
+sncli -k somekeyid tag add "tag3"           # Now tagged as "tag1,tag2,tag3"
 
 # Remove a tag from a note
-sncli -k somekeyid tag rm "tag3"            # Now tagged as "tag2,tag4"
+sncli -k somekeyid tag rm "tag2"            # Now tagged as "tag1,tag3"
 
 # Overwrite all of the tags for a note
-sncli -k somekeyid tag set "tag2,tag3"      # Now tagged as "tag2,tag3"
+sncli -k somekeyid tag set "tag2,tag4"      # Now tagged as "tag2,tag4"
 ```
 
 Note that in SimpleNote, tags are case-insensitive, so "TAG2", "tag2", and 

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -1201,9 +1201,17 @@ class sncli:
             return
 
         tags = utils.get_note_tags(note)
-        if tags:
-            print(tags)
+        return tags
 
+    def cli_note_tags_set(self, key, tags):
+
+        note = self.ndb.get_note(key)
+        if not note:
+            self.log('Error: Key does not exist')
+            return
+
+        self.ndb.set_note_tags(key, tags)
+        self.sync_notes()
 
 def SIGINT_handler(signum, frame):
     print('\nSignal caught, bye!')
@@ -1239,6 +1247,8 @@ Usage:
   < trash | untrash >         - trash/untrash a note (specified by <key>)
   < pin | unpin >             - pin/unpin a note (specified by <key>)
   < markdown | unmarkdown >   - markdown/unmarkdown a note (specified by <key>)
+  tag get                     - retrieve the tags from a note (specified by <key>)
+  tag set <tags>              - set the tags for a note (specified by <key>)
 ''')
     sys.exit(0)
 
@@ -1367,14 +1377,20 @@ def main(argv=sys.argv[1:]):
     # Tag API
     elif args[0] == 'tag':
 
+        if not key:
+            usage()
+
         if args[1] == 'get':
 
-            if not key:
-                usage()
-
             sn = sncli_start()
-            sn.cli_note_tags_get(key)
+            tags = sn.cli_note_tags_get(key)
+            print(tags)
 
+        elif args[1] == 'set':
+
+            tags = args[2]
+            sn = sncli_start()
+            sn.cli_note_tags_set(key, tags)
 
     else:
         usage()

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -1426,7 +1426,8 @@ def main(argv=sys.argv[1:]):
 
             sn = sncli_start()
             tags = sn.cli_note_tags_get(key)
-            print(tags)
+            if tags:
+                print(tags)
 
         elif args[1] == 'set':
 

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -1235,6 +1235,24 @@ class sncli:
 
         self.cli_note_tags_set(key, tags)
 
+    def cli_note_tags_rm(self, key, rm_tags):
+
+        note = self.ndb.get_note(key)
+        if not note:
+            self.log('Error: Key does not exist')
+            return
+
+        old_tags = self.cli_note_tags_get(key)
+        if old_tags:
+            old_tag_list = old_tags.split(',')
+            rm_tag_list = rm_tags.split(',')
+            tag_list = old_tag_list
+            for tag in rm_tag_list:
+                if tag in tag_list:
+                    tag_list.remove(tag)
+            tags = ','.join(tag_list)
+            self.cli_note_tags_set(key, tags)
+
 def SIGINT_handler(signum, frame):
     print('\nSignal caught, bye!')
     sys.exit(1)
@@ -1272,6 +1290,7 @@ Usage:
   tag get                     - retrieve the tags from a note (specified by <key>)
   tag set <tags>              - set the tags for a note (specified by <key>)
   tag add <tags>              - add tags to a note (specified by <key>)
+  tag rm <tags>               - remove tags from a note (specified by <key>)
 ''')
     sys.exit(0)
 
@@ -1420,6 +1439,12 @@ def main(argv=sys.argv[1:]):
             new_tags = args[2]
             sn = sncli_start()
             sn.cli_note_tags_add(key, new_tags)
+
+        elif args[1] == 'rm':
+
+            rm_tags = args[2]
+            sn = sncli_start()
+            sn.cli_note_tags_rm(key, rm_tags)
 
     else:
         usage()

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -1422,6 +1422,12 @@ def main(argv=sys.argv[1:]):
         if not key:
             usage()
 
+        nargs = len(args)
+        correct_get = (args[1] == 'get' and nargs == 2)
+        correct_other = (args[1] in ['set', 'add', 'rm'] and nargs == 3)
+        if not (correct_get or correct_other):
+            usage()
+
         if args[1] == 'get':
 
             sn = sncli_start()

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -1193,6 +1193,17 @@ class sncli:
         self.ndb.set_note_markdown(key, markdown)
         self.sync_notes()
 
+    def cli_note_tags_get(self, key):
+
+        note = self.ndb.get_note(key)
+        if not note:
+            self.log('ERROR: Key does not exist')
+            return
+
+        tags = utils.get_note_tags(note)
+        if tags:
+            print(tags)
+
 
 def SIGINT_handler(signum, frame):
     print('\nSignal caught, bye!')
@@ -1352,6 +1363,18 @@ def main(argv=sys.argv[1:]):
 
         sn = sncli_start()
         sn.cli_note_markdown(key, 1 if args[0] == 'markdown' else 0)
+
+    # Tag API
+    elif args[0] == 'tag':
+
+        if args[1] == 'get':
+
+            if not key:
+                usage()
+
+            sn = sncli_start()
+            sn.cli_note_tags_get(key)
+
 
     else:
         usage()

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -1223,8 +1223,8 @@ class sncli:
         # Add tag only if it isn't already there
         old_tags = self.cli_note_tags_get(key)
         if old_tags:
-            old_tag_list = old_tags.split(',')
-            new_tag_list = new_tags.split(',')
+            old_tag_list = old_tags.lower().split(',')
+            new_tag_list = new_tags.lower().split(',')
             tag_list = old_tag_list
             for tag in new_tag_list:
                 if tag not in tag_list:
@@ -1244,8 +1244,8 @@ class sncli:
 
         old_tags = self.cli_note_tags_get(key)
         if old_tags:
-            old_tag_list = old_tags.split(',')
-            rm_tag_list = rm_tags.split(',')
+            old_tag_list = old_tags.lower().split(',')
+            rm_tag_list = rm_tags.lower().split(',')
             tag_list = old_tag_list
             for tag in rm_tag_list:
                 if tag in tag_list:

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -1213,6 +1213,28 @@ class sncli:
         self.ndb.set_note_tags(key, tags)
         self.sync_notes()
 
+    def cli_note_tags_add(self, key, new_tags):
+
+        note = self.ndb.get_note(key)
+        if not note:
+            self.log('Error: Key does not exist')
+            return
+
+        # Add tag only if it isn't already there
+        old_tags = self.cli_note_tags_get(key)
+        if old_tags:
+            old_tag_list = old_tags.split(',')
+            new_tag_list = new_tags.split(',')
+            tag_list = old_tag_list
+            for tag in new_tag_list:
+                if tag not in tag_list:
+                    tag_list.append(tag)
+            tags = ','.join(tag_list)
+        else:
+            tags = new_tags
+
+        self.cli_note_tags_set(key, tags)
+
 def SIGINT_handler(signum, frame):
     print('\nSignal caught, bye!')
     sys.exit(1)
@@ -1249,6 +1271,7 @@ Usage:
   < markdown | unmarkdown >   - markdown/unmarkdown a note (specified by <key>)
   tag get                     - retrieve the tags from a note (specified by <key>)
   tag set <tags>              - set the tags for a note (specified by <key>)
+  tag add <tags>              - add tags to a note (specified by <key>)
 ''')
     sys.exit(0)
 
@@ -1391,6 +1414,12 @@ def main(argv=sys.argv[1:]):
             tags = args[2]
             sn = sncli_start()
             sn.cli_note_tags_set(key, tags)
+
+        elif args[1] == 'add':
+
+            new_tags = args[2]
+            sn = sncli_start()
+            sn.cli_note_tags_add(key, new_tags)
 
     else:
         usage()

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -1210,7 +1210,7 @@ class sncli:
             self.log('Error: Key does not exist')
             return
 
-        self.ndb.set_note_tags(key, tags)
+        self.ndb.set_note_tags(key, tags.lower())
         self.sync_notes()
 
     def cli_note_tags_add(self, key, new_tags):


### PR DESCRIPTION
This implements the syntax in #45. The following syntax should work (and works in my local tests):

```
sncli -k <key> tag get   # Retrieve tags

sncli -k <key> tag set "tag1,tag2"   # Sets tags to "tag1,tag2"

sncli -k <key> tag add "tag3"    # Sets tags to "tag1,tag2,tag3"
## Repeating above command will have no effect -- tags are only added if tag doesn't exist

sncli -k <key> tag rm "tag1"   # Sets tags to "tag2,tag3"
## Repeating above command again will have no effect -- tags are only removed if present
```