### PR TITLE
gracefully handle config file errors

### DIFF
--- a/simplenote_cli/config.py
+++ b/simplenote_cli/config.py
@@ -12,6 +12,7 @@ class Config:
         {
          'cfg_sn_username'       : '',
          'cfg_sn_password'       : '',
+         'cfg_sn_password_eval'  : '',
          'cfg_db_path'           : os.path.join(self.home, '.sncli'),
          'cfg_search_tags'       : 'yes',  # with regex searches
          'cfg_sort_mode'         : 'date', # 'alpha' or 'date'
@@ -121,10 +122,24 @@ class Config:
         }
 
         cp = configparser.SafeConfigParser(defaults)
-        if custom_file is not None:
-            self.configs_read = cp.read([custom_file])
-        else:
-            self.configs_read = cp.read([os.path.join(self.home, '.snclirc')])
+
+        fname = custom_file if custom_file is not None else os.path.join(self.home, '.snclirc')
+        try:
+            with open(fname) as f:
+                cp.read_file(f, source=fname)
+        except FileNotFoundError as e:
+            print("Config file not found: '{}'.".format(fname))
+            sys.exit(1)
+        except configparser.Error as e:
+            # catch all parser errors
+            print("Error parsing config file.")
+            print(e)
+            sys.exit(1)
+        except OSError as e:
+            # catch other file related errors
+            print("Error reading config file.")
+            print(e)
+            sys.exit(1)
 
         cfg_sec = 'sncli'
 
@@ -145,6 +160,10 @@ class Config:
                     print('Error evaluating command for password.')
                     print(e)
                     sys.exit(1)
+            else:
+                # no way of obtaining a password!
+                # TODO: gracefully handle
+                pass
 
         # ordered dicts used to ease help
 

--- a/simplenote_cli/notes_db.py
+++ b/simplenote_cli/notes_db.py
@@ -435,7 +435,7 @@ class NotesDB():
         # record that we saved this to disc.
         note['savedate'] = time.time()
 
-    def sync_notes(self, server_sync=True, full_sync=True):
+    def sync_notes(self, server_sync=True, full_sync=True) -> int:
         """Perform a full bi-directional sync with server.
 
         Params:
@@ -446,6 +446,7 @@ class NotesDB():
             changes since the last sync. Full sync should happen on sncli start,
             and partial syncs can happen periodically or after modifying a note.
 
+        Returns number of errors.
 
         This follows the recipe in the SimpleNote 2.0 API documentation.
         After this, it could be that local keys have been changed, so
@@ -678,11 +679,12 @@ class NotesDB():
         self.sync_lock.release()
         return all_saved
 
-    def sync_now(self, do_server_sync=True):
+    def sync_now(self, do_server_sync=True) -> int:
         self.sync_lock.acquire()
-        self.sync_notes(server_sync=do_server_sync,
+        n_errors = self.sync_notes(server_sync=do_server_sync,
                         full_sync=True if not self.last_sync else False)
         self.sync_lock.release()
+        return n_errors
 
     # sync worker thread...
     def sync_worker(self, do_server_sync):

--- a/simplenote_cli/simplenote.py
+++ b/simplenote_cli/simplenote.py
@@ -57,16 +57,16 @@ class Simplenote(object):
         try:
             self.api = self.authenticate(self.username, self.password)
         except ConnectionError as e:
-            logging.debug(e)
+            logging.debug("Auth error: " + str(e))
             self.status = 'offline: no connection'
         except HTTPError as e:
-            logging.debug(e)
+            logging.debug("Auth error: " + str(e))
             self.status = 'offline: login failed; check username and password'
         except KeyError as e:
-            logging.debug(e)
+            logging.debug("Auth error: " + str(e))
             self.status = 'offline: login failed; check username and password'
         except Exception as e:
-            logging.debug(e)
+            logging.debug("Auth error: " + str(e))
             self.status = 'offline: unknown auth error; check log for details'
 
     def authenticate(self, user: str, password: str) -> Api:

--- a/simplenote_cli/simplenote.py
+++ b/simplenote_cli/simplenote.py
@@ -53,6 +53,11 @@ class Simplenote(object):
         self.token = None
         self.status = 'offline'
 
+        if not username or not password:
+            logging.debug('Auth error: username or password not set')
+            self.status = 'offline: username or password not set'
+            return
+
         # attempt initial auth
         try:
             self.api = self.authenticate(self.username, self.password)

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -60,8 +60,8 @@ class sncli:
             self.sync_notes()
             self.verbose = verbose
 
-    def sync_notes(self):
-        self.ndb.sync_now(self.do_server_sync)
+    def sync_notes(self) -> int:
+        return self.ndb.sync_now(self.do_server_sync)
 
     def get_editor(self):
         editor = self.config.get_config('editor')
@@ -1355,7 +1355,11 @@ def main(argv=sys.argv[1:]):
 
     def sncli_start(sync=sync, verbose=verbose, config=config):
         sn = sncli(sync, verbose, config)
-        if sync: sn.sync_notes()
+        if sync: 
+            errors = sn.sync_notes()
+            if errors > 0:
+                print('ERROR: check log for sync errors.')
+                sys.exit(1)
         return sn
 
     if args[0] == 'sync':


### PR DESCRIPTION
- [X] print helpful message and exit on irrecoverable config reading
errors:
  - file not existing
  - file not readable
  - config parse error
- [X] fix unhelpful crash traceback when no password given (by adding a
default value for the password_eval option)
- [ ] decide how to handle no passwords more gracefully (currently
attempts and fails at authenticating with api, resulting in 'offline:
please check password' style message at top of interface, or failure on cli sync)
- [X] exit with error status on cli sync fail

Comments/suggestions welcome.