### PR TITLE
Allow specifying config via SNCLIRC environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,13 @@ The current Simplenote API does not support oauth authentication so your
 Simplenote account information must live in the configuration file. Please be
 sure to protect this file.
 
-sncli pulls in configuration from the `.snclirc` file located in your $HOME
-directory. At the very least, the following example `.snclirc` will get you
-going (using your account information):
+The flow sncli uses for finding the config file is:
+
+1. Specified on the command line with `-c` or `--config`.
+2. If `SNCLIRC` environment variable is set, use that.
+3. Finally will pull from default location of `$HOME/.snclirc`.
+
+The following example `.snclirc` will get you going (using your account information):
 
 ```
 [sncli]

--- a/simplenote_cli/config.py
+++ b/simplenote_cli/config.py
@@ -123,7 +123,13 @@ class Config:
 
         cp = configparser.SafeConfigParser(defaults)
 
-        fname = custom_file if custom_file is not None else os.path.join(self.home, '.snclirc')
+        if custom_file:
+            fname = custom_file
+        elif 'SNCLIRC' in os.environ:
+            fname = os.environ['SNCLIRC']
+        else:
+            fname = os.path.join(self.home, '.snclirc')
+
         try:
             with open(fname) as f:
                 cp.read_file(f, source=fname)


### PR DESCRIPTION
Will now check the following places for a config file and will try the
first one in list:
- value specified with `--config`
- value from `SNCLI` environment variable if set
- `~/.snclirc`

----
I try to make use of the `~/.config` directory for storing config files.  This was the smallest change I could figure out to achieve this.  This lets me set `export SNCLI="${HOME}/.config/sncli/snclirc"` where I can then specify directories for any other config item (ex changing the path of the db directory)

Some basic testing to verify logic:

```shell
$ pipenv run ./sncli
Config file not found: '/home/vr/.snclirc'.
$ pipenv run ./sncli --config /tmp/nonexistent-file
Config file not found: '/tmp/nonexistent-file'.
$ SNCLIRC=/tmp/nonexistent-file-from-env pipenv run ./sncli --config /tmp/nonexistent-file
Config file not found: '/tmp/nonexistent-file'.
$ SNCLIRC=/tmp/nonexistent-file-from-env pipenv run ./sncli
Config file not found: '/tmp/nonexistent-file-from-env'.
```