### PR TITLE
Keep temp files to avoid losing data

### DIFF
--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -120,7 +120,7 @@ class sncli:
             subprocess.check_call(cmd_list)
         except Exception as e:
             self.log('Command error: ' + str(e))
-            temp.tempfile_delete(tf)
+            self.log('Temp file saved: {}'.format(temp.tempfile_name(tf)))
             return None
 
         content = None
@@ -129,7 +129,7 @@ class sncli:
             if not content or content == '\n':
                 content = None
 
-        temp.tempfile_delete(tf)
+        self.log('Temp file saved: {}'.format(temp.tempfile_name(tf)))
         return content
 
     def exec_diff_on_note(self, note, old_note):

--- a/simplenote_cli/temp.py
+++ b/simplenote_cli/temp.py
@@ -7,7 +7,7 @@ import os, json, tempfile
 def tempfile_create(note, raw=False, tempdir=None):
     if raw:
         # dump the raw json of the note
-        tf = tempfile.NamedTemporaryFile(suffix='.json', delete=False, dir=tempdir)
+        tf = tempfile.NamedTemporaryFile(suffix='.json', prefix="sncli-temp-", delete=False, dir=tempdir)
 
         contents = json.dumps(note, indent=2)
         tf.write(contents.encode('utf-8'))
@@ -18,7 +18,7 @@ def tempfile_create(note, raw=False, tempdir=None):
            'systemTags' in note and \
            'markdown' in note['systemTags']:
             ext = '.mkd'
-        tf = tempfile.NamedTemporaryFile(suffix=ext, delete=False, dir=tempdir)
+        tf = tempfile.NamedTemporaryFile(suffix=ext, prefix="sncli-temp-", delete=False, dir=tempdir)
         if note:
             contents = note['content']
             tf.write(contents.encode('utf-8'))


### PR DESCRIPTION
This prevents tempfiles from editing notes from being cleaned up by
sncli. It also logs the filenames to sncli.log for easy discovery.

Ideally we would have a method to auto clean-up the temp files after a
certain time or when it is sure that the notes have been saved and/or
synced. For now this is a solution anyway. For the privacy conscious,
if this PR is merged, it means that tempfiles from your notes will be
left around in the tempdir until manually cleaned up.

Ref #82