### PR TITLE
add option to default to markdown for new notes

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,38 +3,43 @@ Example Configuration
 
 .. caution:: Values must not be quoted!
 
+.. caution:: Note that "yes" is the only support truthy value for boolean options.
+
 ::
 
   [sncli]
   cfg_sn_username = lebowski@thedude.com
   # cfg_sn_password = nihilist
   cfg_sn_password_eval = gpg --quiet --for-your-eyes-only --no-tty --decrypt ~/.sncli-pass.gpg
-  
+
   ## NOTE: if both password config are given, cfg_sn_password will be used
-  
+
   # sets the datebase path for your notes
   cfg_db_path = os.path.join(self.home. .sncli)
-  
+
   # allows you to do regex searches with tags
   cfg_search_tags = yes
-  
+
   # sets the default notes sort
   # can be set to `alpha` or `date`
   cfg_sort_mode = date
-  
+
   # keep pins messages at top
   cfg_pinned_ontop = yes
-  
+
   # sets the default tapstop
   cfg_tabstop = 4
 
   # show the status bar
   cfg_status_bar = yes
 
+  # default to markdown instead of plaintext
+  cfg_default_markdown = yes
+
   ### DATE
   ## run `man strftime` for all options
   # cfg_format_strftime = %Y/%m/%d
-  cfg_format_stftime = %d %B %Y   
+  cfg_format_stftime = %d %B %Y
 
   ### TITLES
   ## %D - date
@@ -46,7 +51,7 @@ Example Configuration
     # S - published/shared
     # m - markdown
   ## The dash changes text alignment to the left
-  cfg_format_note_title = [%D] %F %-N %T 
+  cfg_format_note_title = [%D] %F %-N %T
 
   ### EDITOR and PAGER
   # sncli will check your configuration file for the $EDITOR,
@@ -54,10 +59,10 @@ Example Configuration
   ## WARNING: if neither $EDITOR or cfg_editor is set, it will be impossible to edit notes
   # `{fname}` is substituted with the filename
   # `{line}` is substituted for the current line number in sncli's pager
-  
+
   # The default editor and pager
   # cfg_editor = os.environ[EDITOR] if EDITOR in os.environ else vim {fname} +{line}
-  # cfg_pager = os.environ[PAGER] if PAGER in os.environ else less -c 
+  # cfg_pager = os.environ[PAGER] if PAGER in os.environ else less -c
   ## If {fname} isn't supplied, the filename is simply appended
 
   # EXAMPLES
@@ -67,7 +72,7 @@ Example Configuration
 
   # set the pager
   cfg_pager = less -c +{line} -N {fname}
-  
+
   # set the diff pager
   # cfg_diff = diff -b -U10
   cfg_diff = colordiff -bl
@@ -75,7 +80,7 @@ Example Configuration
   ### THE LOG
   # set the max number of logs sncli saves
   cfg_max_logs = 5
-  
+
   # set the log timeout
   cfg_log_timeout = 5
 
@@ -110,9 +115,9 @@ Example Configuration
   # sync notes
   kb_sync = S
 
-  # scroll down one note 
+  # scroll down one note
   kb_down = j
-  
+
   # scroll up one note
   kb_up = k
 
@@ -140,7 +145,7 @@ Example Configuration
   # create a new note
   kb_create_note = C
 
-  # edit a note 
+  # edit a note
   kb_edit_note = e
 
   # view note in the pager
@@ -234,7 +239,7 @@ Example Configuration
   # `fg` means foreground, the text color
   # `bg` means background color
 
-  ## COMMON 
+  ## COMMON
   # the status bar
   clr_status_bar_fg = dark gray
   clr_status_bar_bg = light gray
@@ -251,7 +256,7 @@ Example Configuration
   # the selected note,
   clr_note_focus_fg = white
   clr_note_focus_bg = light red
-  
+
   # titles of notes that have been updated in the last 24 hours
   clr_note_title_day_fg = light red
   clr_note_title_day_bg = default
@@ -267,11 +272,11 @@ Example Configuration
   # titles of notes that have note been updated in a year
   clr_note_title_year_fg = light blue
   clr_note_title_year_bg = default
- 
+
   # titles of notes that were last updated over a year ago
   clr_note_title_ancient_fg = light blue
   clr_note_title_ancient_bg = default
- 
+
   # for the date
   clr_note_date_fg = dark blue
   clr_note_date_bg = default
@@ -329,5 +334,5 @@ Example Configuration
   clr_help_descr_bg = default
 
   ### NOTE: You do not need to keep default vaules in your config
-  # they are listed here as examples to give a complete view of 
+  # they are listed here as examples to give a complete view of
   # what setting are customizable.

--- a/simplenote_cli/config.py
+++ b/simplenote_cli/config.py
@@ -28,6 +28,7 @@ class Config:
          'cfg_log_timeout'       : '5',
          'cfg_log_reversed'      : 'yes',
          'cfg_tempdir'           : '',
+         'cfg_default_markdown'  : 'no',
 
          'kb_help'            : 'h',
          'kb_quit'            : 'q',
@@ -191,6 +192,7 @@ class Config:
         self.configs['log_timeout'] = [ cp.get(cfg_sec, 'cfg_log_timeout'), 'Log timeout' ]
         self.configs['log_reversed'] = [ cp.get(cfg_sec, 'cfg_log_reversed'), 'Log file reversed' ]
         self.configs['tempdir'] = [ cp.get(cfg_sec, 'cfg_tempdir'), 'Temporary directory for note storage' ]
+        self.configs['default_markdown'] = [ cp.get(cfg_sec, 'cfg_default_markdown'), 'Default to markdown for new notes' ]
 
         self.keybinds = collections.OrderedDict()
         self.keybinds['help'] = [ cp.get(cfg_sec, 'kb_help'), [ 'common' ], 'Help' ]

--- a/simplenote_cli/notes_db.py
+++ b/simplenote_cli/notes_db.py
@@ -324,7 +324,7 @@ class NotesDB():
 
         return new_key
 
-    def create_note(self, content):
+    def create_note(self, content, markdown=False):
         # need to get a key unique to this database. not really important
         # what it is, as long as it's unique.
         new_key = utils.generate_random_key()
@@ -342,8 +342,12 @@ class NotesDB():
                     'creationDate' : timestamp,
                     'savedate'   : 0, # never been written to disc
                     'syncdate'   : 0, # never been synced with server
-                    'tags'       : []
+                    'tags'       : [],
+                    'systemTags' : [],
                    }
+
+        if markdown:
+            new_note['systemTags'].append('markdown')
 
         self.notes[new_key] = new_note
 

--- a/simplenote_cli/simplenote.py
+++ b/simplenote_cli/simplenote.py
@@ -152,7 +152,7 @@ class Simplenote(object):
                     'content': note['content'],
                     'modificationDate': note['modificationDate'],
                     'creationDate': note['creationDate'],
-                    'systemTags': [],
+                    'systemTags': note['systemTags'],
                     'shareURL': '',
                     'publishURL': '',
                 }

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -44,6 +44,9 @@ class sncli:
 
         self.logs = []
 
+        # whether to default to markdown for new notes or note
+        self.default_markdown = self.config.get_config('default_markdown') == 'yes'
+
         try:
             self.ndb = NotesDB(self.config, self.log, self.gui_update_view)
         except Exception as e:
@@ -91,7 +94,12 @@ class sncli:
         if not cmd:
             return None
 
-        tf = temp.tempfile_create(note if note else None, raw=raw, tempdir=self.tempdir)
+        tf = temp.tempfile_create(
+            note if note else None,
+            raw=raw,
+            tempdir=self.tempdir,
+            ext_override='.mkd' if self.default_markdown else '.txt',
+        )
         fname = temp.tempfile_name(tf)
 
         focus_position = 0
@@ -641,7 +649,7 @@ class sncli:
 
             if content:
                 self.log('New note created')
-                self.ndb.create_note(content)
+                self.ndb.create_note(content, markdown=self.default_markdown)
                 self.gui_update_view()
                 self.ndb.sync_worker_go()
 
@@ -1122,7 +1130,7 @@ class sncli:
 
         if content:
             self.log('New note created')
-            self.ndb.create_note(content)
+            self.ndb.create_note(content, markdown=self.default_markdown)
             self.sync_notes()
 
     def cli_note_import(self, from_stdin):

--- a/simplenote_cli/temp.py
+++ b/simplenote_cli/temp.py
@@ -4,7 +4,7 @@
 
 import os, json, tempfile, time
 
-def tempfile_create(note, raw=False, tempdir=None):
+def tempfile_create(note, raw=False, tempdir=None, ext_override=None):
     if raw:
         # dump the raw json of the note
         tf = tempfile.NamedTemporaryFile(suffix='.json', prefix=_get_tempfile_prefix(), delete=False, dir=tempdir)
@@ -14,7 +14,9 @@ def tempfile_create(note, raw=False, tempdir=None):
         tf.flush()
     else:
         ext = '.txt'
-        if note and \
+        if ext_override:
+            ext = ext_override
+        elif note and \
            'systemTags' in note and \
            'markdown' in note['systemTags']:
             ext = '.mkd'


### PR DESCRIPTION
This adds `cfg_default_markdown` to default to markdown for new notes. This
applies to new notes created from the gui as well as the command line.

when

```
cfg_default_markdown = yes
```

is present in the configuration file, the following changes will be noticed:

- the tempfile for a new note will have a mkd file extension
- the markdown type flag will be set on new notes and synced

fixes #92