### PR TITLE
exec style entrypoint for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /sncli
 WORKDIR /sncli
 RUN pipenv install
 
-ENTRYPOINT pipenv run ./sncli
+ENTRYPOINT ["pipenv", "run", "./sncli"]
 
 # Install editors and tools of your choice
 RUN apt-get update && apt-get install -y neovim && apt-get clean

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Check your OS distribution for installation packages.
   - or with Docker
     - docker build . -t sncli
     - docker run --rm -it -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli
+    - See [Docker Tips](#docker-tips) below for usage instructions for this method
 
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -344,6 +344,26 @@ possibilities here...
 
 _Note: more tips and tricks on the [GitHub wiki](https://github.com/insanum/sncli/wiki/Tips-and-Tricks)!_
 
+### Docker Tips
+
+The Docker installation offers some flexibility in that you don't need to install dependencies outside of Docker itself to run. However, because sncli has both an interactive component as well as being scriptable by passing data via stdin there can be some subtle differences in the Docker command used in some situations. In general, `-it` needs to be passed to the Docker command when trying to use sncli interactively (this gives a full TTY allowing interaction) but only `-i` when trying to pass input. For example:
+
+If you are trying to launch the GUI console, you might run exactly what's in the setup instructions:
+
+`docker run --rm -it -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli`
+
+In order to create a new note from stdin, you'll need to drop the `-t` from the command, but still preserve the `-i` input argument:
+
+`echo "hello world" | docker run --rm -i -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli create -`
+
+The above command can be simplified by using an alias in your shell:
+
+`alias sncli='docker run --rm -i -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli'`
+
+Then you can interact with sncli as though Docker wasn't there (aside from the interactive nuance from above):
+
+`echo "hello world" | sncli create -`
+
 ### Thanks
 
 This application pulls in and uses the

--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ Check your OS distribution for installation packages.
     - Run with `pipenv run sncli`
   - or more manual:
     - `python setup.py install`
-  - or with Docker
+  - or with Docker (see the wiki for [Docker usage tips](https://github.com/insanum/sncli/wiki/Tips-and-Tricks#docker-usage-tips))
     - docker build . -t sncli
     - docker run --rm -it -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli
-    - See [Docker Tips](#docker-tips) below for usage instructions for this method
 
 
 ### Features
@@ -344,26 +343,6 @@ Now when I edit this note Vim will automatically load the votl plugin. Lots of
 possibilities here...
 
 _Note: more tips and tricks on the [GitHub wiki](https://github.com/insanum/sncli/wiki/Tips-and-Tricks)!_
-
-### Docker Tips
-
-The Docker installation offers some flexibility in that you don't need to install dependencies outside of Docker itself to run. However, because sncli has both an interactive component as well as being scriptable by passing data via stdin there can be some subtle differences in the Docker command used in some situations. In general, `-it` needs to be passed to the Docker command when trying to use sncli interactively (this gives a full TTY allowing interaction) but only `-i` when trying to pass input. For example:
-
-If you are trying to launch the GUI console, you might run exactly what's in the setup instructions:
-
-`docker run --rm -it -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli`
-
-In order to create a new note from stdin, you'll need to drop the `-t` from the command, but still preserve the `-i` input argument:
-
-`echo "hello world" | docker run --rm -i -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli create -`
-
-The above command can be simplified by using an alias in your shell:
-
-`alias sncli='docker run --rm -i -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli'`
-
-Then you can interact with sncli as though Docker wasn't there (aside from the interactive nuance from above):
-
-`echo "hello world" | sncli create -`
 
 ### Thanks
 


### PR DESCRIPTION
Hi! I've been playing around with sncli this weekend a bit locally and it's really useful. I see that Docker support was sort of added on recently and I'm not sure if you're interested in maintaining that type of packaging. I noticed that the Docker image is using a shell form entrypoint which is preventing any arguments from being passed to it. From the [Docker documentation](https://docs.docker.com/engine/reference/builder/#entrypoint):

> The shell form prevents any CMD or run command line arguments from being used

This means that no arguments can be passed in, so all you can do from the image is launch the console GUI. That prevents it from being used in any scripting. With this change you can still launch that GUI (which is still the default with no arguments added), but also pass arguments to use it in scripting.