### PR TITLE
fixed windows style newlines in titles and note view

### DIFF
--- a/simplenote_cli/utils.py
+++ b/simplenote_cli/utils.py
@@ -10,6 +10,7 @@ import datetime, random, re, time
 
 # first line with non-whitespace should be the title
 note_title_re = re.compile(r'\s*([^\r\n]*)')
+note_newline_re = re.compile(r'\r?\n')
 
 def generate_random_key():
     """Generate random 30 digit (15 byte) hex string.
@@ -45,6 +46,12 @@ def get_note_flags(note):
     else:
         flags += '   '
     return flags
+
+def get_note_lines(note, max_lines=0):
+    lines = note_newline_re.split(
+        note.get('content', ''),
+        max_lines)
+    return lines
 
 def get_note_title(note):
     mo = note_title_re.match(note.get('content', ''))

--- a/simplenote_cli/utils.py
+++ b/simplenote_cli/utils.py
@@ -9,7 +9,7 @@
 import datetime, random, re, time
 
 # first line with non-whitespace should be the title
-note_title_re = re.compile('\s*(.*)\n?')
+note_title_re = re.compile(r'\s*([^\r\n]*)')
 
 def generate_random_key():
     """Generate random 30 digit (15 byte) hex string.

--- a/simplenote_cli/utils.py
+++ b/simplenote_cli/utils.py
@@ -47,10 +47,8 @@ def get_note_flags(note):
         flags += '   '
     return flags
 
-def get_note_lines(note, max_lines=0):
-    lines = note_newline_re.split(
-        note.get('content', ''),
-        max_lines)
+def get_note_lines(note):
+    lines = note_newline_re.split(note.get('content', ''))
     return lines
 
 def get_note_title(note):

--- a/simplenote_cli/view_note.py
+++ b/simplenote_cli/view_note.py
@@ -30,13 +30,13 @@ class ViewNote(urwid.ListBox):
         if not self.key:
             return lines
         if self.old_note:
-            for l in self.old_note['content'].splitlines():
+            for l in utils.get_note_lines(self.old_note):
                 lines.append(
                     urwid.AttrMap(urwid.Text(l.replace('\t', ' ' * self.tabstop)),
                                   'note_content_old',
                                   'note_content_old_focus'))
         else:
-            for l in self.note['content'].splitlines():
+            for l in utils.get_note_lines(self.note):
                 lines.append(
                     urwid.AttrMap(urwid.Text(l.replace('\t', ' ' * self.tabstop)),
                                   'note_content',
@@ -105,8 +105,9 @@ class ViewNote(urwid.ListBox):
         self.search_note_range(note_range)
 
     def search_note_range(self, note_range):
+        note_lines = utils.get_note_lines(self.note)
         for line in note_range:
-            line_content = self.note['content'].split('\n')[line]
+            line_content = note_lines[line]
             if (self.is_match(self.search_string, line_content)):
                 self.focus_position = line
                 break
@@ -198,7 +199,7 @@ class ViewNote(urwid.ListBox):
                           'status_bar')
 
     def copy_note_text(self):
-        line_content = self.note['content'].split('\n')[self.focus_position]
+        line_content = utils.get_note_lines(self.note)[self.focus_position]
         self.clipboard.copy(line_content)
 
     def keypress(self, size, key):

--- a/simplenote_cli/view_note.py
+++ b/simplenote_cli/view_note.py
@@ -30,13 +30,13 @@ class ViewNote(urwid.ListBox):
         if not self.key:
             return lines
         if self.old_note:
-            for l in self.old_note['content'].split('\n'):
+            for l in self.old_note['content'].splitlines():
                 lines.append(
                     urwid.AttrMap(urwid.Text(l.replace('\t', ' ' * self.tabstop)),
                                   'note_content_old',
                                   'note_content_old_focus'))
         else:
-            for l in self.note['content'].split('\n'):
+            for l in self.note['content'].splitlines():
                 lines.append(
                     urwid.AttrMap(urwid.Text(l.replace('\t', ' ' * self.tabstop)),
                                   'note_content',


### PR DESCRIPTION
I noticed that if you create notes using the Windows SImplenote app, newlines are encoded with \r\n and not \n. This causes the note titles to end in "?" and all newlines to also show a "?" in the note view.

I fixed this by using str.splitlines() instead of str.split('\n') for the note view. I also modified the regex used to determine the title of the note. It now matches all non white spaces characters that are not \r or \n.

Windows Note:
![new-lines-in-windows](https://user-images.githubusercontent.com/1101232/129429572-77521436-f5dd-408f-b36b-c5beea68595c.PNG)

Before Fix:
![before-new-line-fix](https://user-images.githubusercontent.com/1101232/129429583-78df623a-be40-43c6-a837-bf66d82cbe76.PNG)

After Fix:
![after-new-line-fix](https://user-images.githubusercontent.com/1101232/129429587-057b3c92-3100-49eb-9a30-e08f2a9052bd.PNG)
