### PR TITLE
Multiple Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker run --rm -it -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli
 FROM python:3.8-buster
 
-ARG editor_packages="neovim"
+ARG editor_packages="vim"
 
 # Install editors and tools of your choice
 ARG DEBIAN_FRONTEND=noninteractive
@@ -26,5 +26,3 @@ RUN \
 COPY . /sncli/
 
 ENTRYPOINT [ "pipenv", "run", "./sncli" ]
-
-# ENV EDITOR /usr/bin/nvim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,30 @@
-# docker build . -t sncli
+# docker build . [--build-arg editor_packages=neovim] -t sncli
 # docker run --rm -it -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli
 FROM python:3.8-buster
 
-RUN pip3 install pipenv
-
-COPY . /sncli
-WORKDIR /sncli
-RUN pipenv install
-
-ENTRYPOINT ["pipenv", "run", "./sncli"]
+ARG editor_packages="neovim"
 
 # Install editors and tools of your choice
-RUN apt-get update && apt-get install -y neovim && apt-get clean
+ARG DEBIAN_FRONTEND=noninteractive
+RUN \
+    apt-get update && \
+    apt-get install -y \
+      ${editor_packages} \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/
+
+RUN pip3 install --no-cache pipenv
+
+COPY ./Pipfile /sncli/
+COPY ./Pipfile.lock /sncli/
+WORKDIR /sncli/
+RUN \
+    pipenv install && \
+    pipenv --clear
+
+COPY . /sncli/
+
+ENTRYPOINT [ "pipenv", "run", "./sncli" ]
+
 # ENV EDITOR /usr/bin/nvim


### PR DESCRIPTION
From commit message:
- Expose 'editor_packages' build `ARG` to allow custom building. Update example.
- Organize build steps to speed up repeated builds by taking advantage of image layer caching.
- Clear 'pipenv' caches and disable 'pip' caching to reduce image size.
- Properly set `DEBIAN_FRONTEND` environment variable on 'apt-get' invocation.

Test it locally by building simply doing:
```
docker build --build-arg editor_packages="nano" github.com/pataquets/sncli -t sncli:nano
```
Make sure to set the `EDITOR` environment variable (using `docker run`'s `-e` switch) accordingly when launching a container.