### PR TITLE
Dockerfile: Upgrade base image. Python 3.8->3.9 ; Debian Buster->Bullseye.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . [--build-arg editor_packages=neovim] -t sncli
 # docker run --rm -it -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli
-FROM python:3.8-buster
+FROM python:3.9-bullseye
 
 ARG editor_packages="vim"
 


### PR DESCRIPTION
As discussed on #115.