### PR TITLE
Fix tempfile suffix logic

### DIFF
--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -98,7 +98,7 @@ class sncli:
             note if note else None,
             raw=raw,
             tempdir=self.tempdir,
-            ext_override='.mkd' if self.default_markdown else '.txt',
+            default_markdown=self.default_markdown,
         )
         fname = temp.tempfile_name(tf)
 

--- a/simplenote_cli/temp.py
+++ b/simplenote_cli/temp.py
@@ -4,7 +4,7 @@
 
 import os, json, tempfile, time
 
-def tempfile_create(note, raw=False, tempdir=None, ext_override=None):
+def tempfile_create(note, raw=False, tempdir=None, default_markdown=False):
     if raw:
         # dump the raw json of the note
         tf = tempfile.NamedTemporaryFile(suffix='.json', prefix=_get_tempfile_prefix(), delete=False, dir=tempdir)
@@ -13,13 +13,12 @@ def tempfile_create(note, raw=False, tempdir=None, ext_override=None):
         tf.write(contents.encode('utf-8'))
         tf.flush()
     else:
-        ext = '.txt'
-        if ext_override:
-            ext = ext_override
-        elif note and \
-           'systemTags' in note and \
-           'markdown' in note['systemTags']:
-            ext = '.mkd'
+        if note:
+            ext = (
+                '.mkd' if 'markdown' in note.get('systemTags', []) else '.txt'
+            )
+        else:
+            ext = '.mkd' if default_markdown else '.txt'
         tf = tempfile.NamedTemporaryFile(suffix=ext, prefix=_get_tempfile_prefix(), delete=False, dir=tempdir)
         if note:
             contents = note['content']


### PR DESCRIPTION
Previously the file extension (suffix) only depended on
the value of `cfg_default_markdown`,
which wasn't helpful for editing existing notes.

Ensure that for existing notes,
the file extension for tempfiles passed to the editor
matches that of the note type (plain text or markdown).
Retain the old behaviour for new notes.
