### PR TITLE
Switch to .md file ext for editing markdown notes

### DIFF
--- a/simplenote_cli/temp.py
+++ b/simplenote_cli/temp.py
@@ -15,10 +15,10 @@ def tempfile_create(note, raw=False, tempdir=None, default_markdown=False):
     else:
         if note:
             ext = (
-                '.mkd' if 'markdown' in note.get('systemTags', []) else '.txt'
+                '.md' if 'markdown' in note.get('systemTags', []) else '.txt'
             )
         else:
-            ext = '.mkd' if default_markdown else '.txt'
+            ext = '.md' if default_markdown else '.txt'
         tf = tempfile.NamedTemporaryFile(suffix=ext, prefix=_get_tempfile_prefix(), delete=False, dir=tempdir)
         if note:
             contents = note['content']

--- a/simplenote_cli/utils.py
+++ b/simplenote_cli/utils.py
@@ -73,7 +73,7 @@ def get_note_title_file(note):
             fn = str(fn)
 
         if note_markdown(note):
-            fn += '.mkdn'
+            fn += '.md'
         else:
             fn += '.txt'
 


### PR DESCRIPTION
This is regarding the file extension used for temporary files
that are passed to the configured editor for editing notes.

Previously it was `.mkd` for markdown notes, which is non-standard.
By switching to the `.md` standard extension,
we can improve compatibility with editors.

---

Note that this may be a breaking change to some users,
if they had scripts that depended on the `.mkd` extension.
I propose keeping this PR open for a while before merging
to allow for comments or push back.
