### PR TITLE
Add 'Publish Docker image' Github Action and enable Dependabot for it.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,49 @@
+name: Publish Docker image
+
+on: push
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      # Required if building multi-arch images
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - id: buildx
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/386
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Finally, I gave a stab at #107 using Github Actions. :tada:

Github Action requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (generated on [DH's security settings](https://hub.docker.com/settings/security) page) to be set in the Github secrets section in the repo config. 
Git pushes will trigger this Github Action to build Docker images and push them to Docker Hub:
* Git branch `branchname` pushes `sncli:branchname` image tag. Thus, `sncli:master` acts as an edge/unreleased/HEAD image tag. Other branches push to their respective image tags (useful for testing feature branches),
* Git tags `X.Y.Z` or `vX.Y.X` push to `sncli:X.Y.Z`, `sncli:X.Y`, `sncli:X` and `sncli:latest`.`:latest` tag is the default when pulling if no tag specified, so `docker pull insanum/sncli` pulls latest `HEAD` code (assuming `insanum` is your Docker Hub user).

Also enabled Dependabot (only for Github Actions manifests). No need to toggle or configure anything.

Also, I've noticed no tag has been pushed since a while ago. Fancy to create a release to test it out? :wink: