### PR TITLE
Dockerfile: add pager packages and locale support via ARG parameters.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 FROM python:3.9-bullseye
 
 ARG editor_packages="vim"
+ARG pager_packages="less"
+
+ARG locale="en_US.UTF-8"
+ARG charset="UTF-8"
 
 # Install editors and tools of your choice
 ARG DEBIAN_FRONTEND=noninteractive
@@ -10,9 +14,15 @@ RUN \
     apt-get update && \
     apt-get install -y \
       ${editor_packages} \
+      ${pager_packages} \
+      locales \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/
+
+RUN \
+    echo "${locale} ${charset}" | tee /etc/locale.gen \
+    && locale-gen
 
 RUN pip3 install --no-cache pipenv
 


### PR DESCRIPTION
* Docker image had no pager installed by default. Can be configured via `pager_packages` build `ARG` (defaults to `less`).
* No locale/charset support. Added `locale` and `charset` build `ARG`s. Defaults to `en_US.UTF-8` and `UTF-8`, respectively.

Helps in troubleshooting #118, as explained in https://github.com/insanum/sncli/pull/118#issuecomment-1255234457.