### PR TITLE
Jump to line with the edit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Usage:
   import [-]                  - import a note in JSON format ('-' JSON from stdin)
   export                      - export a note in JSON format (specified by <key>)
   dump                        - dump a note (specified by <key>)
-  edit                        - edit a note (specified by <key>)
+  edit [+line_number]         - edit a note (specified by <key>, optionally jump to line)
   < trash | untrash >         - trash/untrash a note (specified by <key>)
   < pin | unpin >             - pin/unpin a note (specified by <key>)
   < markdown | unmarkdown >   - markdown/unmarkdown a note (specified by <key>)


### PR DESCRIPTION
I find myself wanting to use the `edit` command and provide a `+<linenumber>` to directly jump to a certain line in my editor (vim).

I've attempted to implement it. 

A command to use it will look like
```
sncli -k <key> edit +7
```
this relies in `cfg_editor` to be set with a `+{line}`:
```
cfg_editor = nvim {fname} +{line}
```

For now I made the overall changes in 2 different commits.
The first one just adds a simple `line` parameter to the `exec_cmd_on_note` method.
On the second one the approach is generalised to pass a `cmd_args` dictionary that can be used to substitute different parameters in the `cmd` string.
This is not necessarily useful right now but I felt it makes a bit more sense to pass generic parameters in like this. 
With the current implementation the only 2 parameters that can be substituted are `fname` and `line` and it practically only really makes sense to pass in a `line` number from the edit command for now.
This is why I kept the 2 commit separate so that I can just use the simpler solution if that's preferred.

Happy to hear opinions and potentially tweak the solution s bit more.
