### PR TITLE
Fix issue #129 pep-8 sorted imports

### DIFF
--- a/simplenote_cli/clipboard.py
+++ b/simplenote_cli/clipboard.py
@@ -1,6 +1,6 @@
 import os
 from distutils import spawn
-from subprocess import Popen, PIPE
+from subprocess import PIPE, Popen
 
 
 class Clipboard(object):

--- a/simplenote_cli/config.py
+++ b/simplenote_cli/config.py
@@ -2,7 +2,14 @@
 # Copyright (c) 2014 Eric Davis
 # Licensed under the MIT License
 
-import os, sys, urwid, collections, configparser, subprocess
+import collections
+import configparser
+import os
+import subprocess
+import sys
+
+import urwid
+
 
 class Config:
 

--- a/simplenote_cli/notes_db.py
+++ b/simplenote_cli/notes_db.py
@@ -6,10 +6,18 @@
 # copyright 2012 by Charl P. Botha <cpbotha@vxlabs.com>
 # new BSD license
 
-import os, time, re, glob, json, copy, threading
+import copy
+import glob
+import json
+import logging
+import os
+import re
+import threading
+import time
+
 from . import utils
 from .simplenote import Simplenote
-import logging
+
 
 class ReadError(RuntimeError):
     pass

--- a/simplenote_cli/simplenote.py
+++ b/simplenote_cli/simplenote.py
@@ -23,8 +23,7 @@ import urllib.parse
 import uuid
 
 import requests
-from requests.exceptions import ConnectionError, RequestException, HTTPError
-
+from requests.exceptions import ConnectionError, HTTPError, RequestException
 from simperium.core import Api, Auth
 
 # Application token provided for sncli.

--- a/simplenote_cli/sncli.py
+++ b/simplenote_cli/sncli.py
@@ -2,15 +2,30 @@
 # Copyright (c) 2014 Eric Davis
 # Licensed under the MIT License
 
-import os, sys, getopt, re, signal, time, datetime, shlex, hashlib
-import subprocess, threading, logging
-import copy, json, urwid, datetime
-from . import view_titles, view_note, view_help, view_log, user_input
-from . import utils, temp
-from .config import Config
-from .simplenote import Simplenote
-from .notes_db import NotesDB, ReadError, WriteError
+import copy
+import datetime
+import getopt
+import hashlib
+import json
+import logging
+import os
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import threading
+import time
 from logging.handlers import RotatingFileHandler
+
+import urwid
+
+from . import (temp, user_input, utils, view_help, view_log, view_note,
+               view_titles)
+from .config import Config
+from .notes_db import NotesDB, ReadError, WriteError
+from .simplenote import Simplenote
+
 
 class sncli:
 

--- a/simplenote_cli/temp.py
+++ b/simplenote_cli/temp.py
@@ -2,7 +2,11 @@
 # Copyright (c) 2014 Eric Davis
 # Licensed under the MIT License
 
-import os, json, tempfile, time
+import json
+import os
+import tempfile
+import time
+
 
 def tempfile_create(note, raw=False, tempdir=None, default_markdown=False):
     if raw:

--- a/simplenote_cli/user_input.py
+++ b/simplenote_cli/user_input.py
@@ -4,6 +4,7 @@
 
 import urwid
 
+
 class UserInput(urwid.Edit):
 
     def __init__(self, config, caption, edit_text, callback_func, args):

--- a/simplenote_cli/utils.py
+++ b/simplenote_cli/utils.py
@@ -6,7 +6,10 @@
 # copyright 2012 by Charl P. Botha <cpbotha@vxlabs.com>
 # new BSD license
 
-import datetime, random, re, time
+import datetime
+import random
+import re
+import time
 
 # first line with non-whitespace should be the title
 note_title_re = re.compile(r'\s*([^\r\n]*)')

--- a/simplenote_cli/view_help.py
+++ b/simplenote_cli/view_help.py
@@ -2,7 +2,10 @@
 # Copyright (c) 2014 Eric Davis
 # Licensed under the MIT License
 
-import re, urwid
+import re
+
+import urwid
+
 
 class ViewHelp(urwid.ListBox):
 

--- a/simplenote_cli/view_log.py
+++ b/simplenote_cli/view_log.py
@@ -4,6 +4,7 @@
 
 import urwid
 
+
 class ViewLog(urwid.ListBox):
 
     def __init__(self, config):

--- a/simplenote_cli/view_note.py
+++ b/simplenote_cli/view_note.py
@@ -2,11 +2,15 @@
 # Copyright (c) 2014 Eric Davis
 # Licensed under the MIT License
 
-import time, urwid
-from . import utils
-import re
-from .clipboard import Clipboard
 import logging
+import re
+import time
+
+import urwid
+
+from . import utils
+from .clipboard import Clipboard
+
 
 class ViewNote(urwid.ListBox):
 

--- a/simplenote_cli/view_titles.py
+++ b/simplenote_cli/view_titles.py
@@ -2,8 +2,15 @@
 # Copyright (c) 2014 Eric Davis
 # Licensed under the MIT License
 
-import re, time, datetime, urwid, subprocess
+import datetime
+import re
+import subprocess
+import time
+
+import urwid
+
 from . import utils, view_note
+
 
 class ViewTitles(urwid.ListBox):
 


### PR DESCRIPTION
Used isort to automate. Now have per line imports following pep8 order. Remove duplicate datetime import.