### PR TITLE
Dockerfile: allow specifying build's Python version via ARG parameter.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # docker build . [--build-arg editor_packages=neovim] -t sncli
 # docker run --rm -it -v /tmp:/tmp -v "$HOME/.sncli/:/root/.sncli/" -v "$HOME/.snclirc:/root/.snclirc" sncli
-FROM python:3.9-bullseye
+ARG python_version="3.9"
+FROM python:${python_version}-bullseye
 
 ARG editor_packages="vim"
 ARG pager_packages="less"


### PR DESCRIPTION
Enabling quick testing of Python updates:
```
docker build --build-arg python_version=3.11 ...
```
Defaults to currently used version on Dockerfile.