### PR TITLE
Bump version, add build docs for pypi release

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,18 @@ There is **partial** Windows support:
     * UI interaction does not work BUT can be made to partially work via a monkey patch to Urwid (see https://github.com/urwid/urwid/issues/447)
     * See https://github.com/insanum/sncli/issues/119 for details
 
+### Building and releasing
+
+First, bump the version in setup.py.
+Ensure python-build and twine are installed on your system.
+
+Run:
+
+```
+python -m build  # build the source and built distributions, outputs to dist/
+twine upload dist/*  # Upload to pypi.  This may prompt for your pypi token.
+```
+
 ### Thanks
 
 This application pulls in and uses the

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ deps = ['urwid', 'requests', 'Simperium3']
 setup(
       name='sncli',
       description='Simplenote Command Line Interface',
-      version='0.4.2',
+      version='0.4.3',
       author='Eric Davis',
       author_email='edavis@insanum.com',
       url='https://github.com/insanum/sncli',


### PR DESCRIPTION
I still maintain the sncli pypi release ( https://pypi.org/project/sncli/ ),
as I've been unable to hand it off yet.

So I cut a new minor release from master and pushed it to pypi: 0.4.3.  Seems safe as there have been no new changes since mid 2023, and things sound fairly stable.

Diff: https://github.com/insanum/sncli/compare/0.4.2...samuelengineer:sncli:0.4.3-pypi

Also added build and release instructions to the readme for future reference.

Happy to hand over pypi maintainership to maintainers here. :)