### PR TITLE
Updates to support py3.12

### DIFF
--- a/simplenote_cli/clipboard.py
+++ b/simplenote_cli/clipboard.py
@@ -1,5 +1,4 @@
-import os
-from distutils import spawn
+from shutil import which
 from subprocess import Popen, PIPE
 
 
@@ -8,9 +7,9 @@ class Clipboard(object):
         self.copy_command = self.get_copy_command()
 
     def get_copy_command(self):
-        if (spawn.find_executable('xsel')):
+        if (which('xsel')):
             return ['xsel', '-ib']
-        if (spawn.find_executable('pbcopy')):
+        if (which('pbcopy')):
             return ['pbcopy']
         return None
 

--- a/simplenote_cli/config.py
+++ b/simplenote_cli/config.py
@@ -122,7 +122,7 @@ class Config:
          'clr_help_descr_bg'             : 'default'
         }
 
-        cp = configparser.SafeConfigParser(defaults)
+        cp = configparser.ConfigParser(defaults)
 
         if custom_file:
             fname = custom_file


### PR DESCRIPTION
two updates to make sncli support python 3.12:

1. #136   Module 'configparser' has no attribute 'SafeConfigParser' in Python 3.12
2. #137  distutils is removed in Python 3.12