### PR TITLE
Bump version, update build & release docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # venv dirs
 env/
 venv/
+.venv/
 
 # python packaging files/dirs
 build

--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ Ensure python-build and twine are installed on your system.
 Run:
 
 ```
+# activate venv
+pip install -r requirements-release.txt  # install build and twine packages
 python -m build  # build the source and built distributions, outputs to dist/
 twine upload dist/*  # Upload to pypi.  This may prompt for your pypi token.
 ```

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,0 +1,2 @@
+build
+twine

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ deps = ['urwid', 'requests', 'Simperium3']
 setup(
       name='sncli',
       description='Simplenote Command Line Interface',
-      version='0.4.3',
+      version='0.4.4',
       author='Eric Davis',
       author_email='edavis@insanum.com',
       url='https://github.com/insanum/sncli',


### PR DESCRIPTION
Bumps the version to 0.4.4 to include recent changes to support more modern Python (3.12) versions.

Updates .gitignore to ignore `.venv/` virtualenv directory.

Adds requirements-release.txt with needed `build` and `twine` packages.

Also updates the build & release docs in the README to reflect newly added requirements-release.txt.